### PR TITLE
Point to personal branch of z3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "z3-sys/z3"]
 	path = z3-sys/z3
-	url = https://github.com/Z3Prover/z3.git
+	url = https://github.com/jagill/z3.git

--- a/z3-sys/src/lib.rs
+++ b/z3-sys/src/lib.rs
@@ -7482,10 +7482,4 @@ extern "C" {
     pub fn Z3_qe_lite(c: Z3_context, vars: Z3_ast_vector, body: Z3_ast) -> Z3_ast;
 }
 
-#[cfg(not(windows))]
-#[link(name = "z3")]
-extern "C" {}
-
-#[cfg(windows)]
-#[link(name = "libz3")]
 extern "C" {}

--- a/z3/Cargo.toml
+++ b/z3/Cargo.toml
@@ -34,4 +34,3 @@ semver = "0.9"
 
 [dependencies.z3-sys]
 path = "../z3-sys"
-version = "0.6.3"


### PR DESCRIPTION
This branch has changes necessary to build this project with Buck:
* It has the generated header/cpp files checked in, because
our build system won't generate them for us.
* We remove the #[link()] directives in z3-sys, because we'll be including
the C Z3 lib statically.
* We then need to point z3 to depend on our repo for z3-sys.